### PR TITLE
Add ability to update a review

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -14,6 +14,22 @@ class ReviewsController < ApplicationController
     end
   end
 
+  def edit
+    @item = Item.find(params[:item_id])
+    @review = Review.find(params[:review_id])
+  end
+
+  def update
+    @item = Item.find(params[:item_id])
+    @review = Review.find(params[:review_id])
+    if @review.update(review_params)
+      redirect_to "/items/#{@item.id}"
+    else
+      flash[:notice] = "Review not submitted: Required information is missing"
+      render :edit
+    end
+  end
+
   private
     def review_params
       params.permit(:title,:content,:rating)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -20,6 +20,7 @@
         <p> <%= review.title %> </p>
         <p> <%= review.content %> </p>
         <p>Rating: <%= review.rating %> </p>
+        <p> <%= button_to 'Edit Review',"/items/#{@item.id}/reviews/#{review.id}/edit", method: :get %></p>
       </section>
       <% end %>
       <p><%= link_to "Edit Item", "/items/#{@item.id}/edit" %></p>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,0 +1,15 @@
+<h1>Edit review for <%= link_to "#{@item.name}", "/items/#{@item.id}" %> </h1>
+<center>
+  <%= form_tag "/items/#{@item.id}/reviews/#{@review.id}", method: :patch do %>
+    <%= label_tag :title %>
+    <%= text_field_tag :title, @review.title %>
+
+    <%= label_tag :content %>
+    <%= text_field_tag :content, @review.content %>
+
+    <%= label_tag "Rating (whole number 1 to 5)" %>
+    <%= text_field_tag :rating, @review.rating %>
+
+    <%= submit_tag 'Update Review' %>
+  <% end %>
+</center>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,12 @@ Rails.application.routes.draw do
   get "/items", to: "items#index"
   get "/items/:id", to: "items#show"
   get "/items/:id/edit", to: "items#edit"
+
   get "/items/:id/reviews/new", to: "reviews#new"
+  get "/items/:item_id/reviews/:review_id/edit", to: "reviews#edit"
   post "/items/:id/reviews", to: "reviews#create"
+  patch "/items/:item_id/reviews/:review_id", to: "reviews#update"
+
   patch "/items/:id", to: "items#update"
   get "/merchants/:merchant_id/items", to: "items#index"
   get "/merchants/:merchant_id/items/new", to: "items#new"

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -37,4 +37,18 @@ RSpec.describe 'item show page', type: :feature do
       expect(page).to have_content(5)
     end
   end
+
+  it 'shows a link to edit a review' do
+    review_1 = @chain.reviews.create(title: "first review", content: "content", rating: 4)
+
+    visit "/items/#{@chain.id}"
+
+    within "#review-#{review_1.id}" do
+      expect(page).to have_button("Edit Review")
+      
+      click_button "Edit Review"
+
+      expect(current_path).to eq("/items/#{@chain.id}/reviews/#{review_1.id}/edit")
+    end
+  end
 end

--- a/spec/features/reviews/edit_spec.rb
+++ b/spec/features/reviews/edit_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe "as a visitor" do
+  describe "when I visit the Review Edit Page" do
+    it "I can modify title, content, rating" do
+      meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      tire = meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      review = tire.reviews.create(title: "first review", content: "content", rating: 4)
+
+      visit "/items/#{tire.id}/reviews/#{review.id}/edit"
+
+      expect(find_field(:title).value).to eq(review.title)
+      expect(find_field(:content).value).to eq(review.content)
+      expect(find_field(:rating).value).to eq(review.rating.to_s)
+
+      fill_in :title, with: "Love It!"
+      fill_in :content, with: "I'd buy it again, totally fixed my bike issues!"
+      fill_in :rating, with: 5
+
+      click_button 'Update Review'
+
+      expect(current_path).to eq("/items/#{tire.id}")
+
+      within "#review-#{review.id}" do
+        expect(page).to have_content("Love It!")
+        expect(page).to have_content("I'd buy it again, totally fixed my bike issues!")
+        expect(page).to have_content(5)
+
+        expect(page).to_not have_content("first review")
+        expect(page).to_not have_content("content")
+        expect(page).to_not have_content(4)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- User can click on button to update an item's review
- User is redirected to pre-populated form to edit title, content & rating
- All fields must be valid for updated review to be accepted
- After submitting form, page redirects to item show page, where updated review is displayed
- All tests passing

Co-authored-by: Ryan Hantak <47759923+rhantak@users.noreply.github.com>