### PR TITLE
Item show page no longer renders helpful reviews twice if less than 6…

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -17,6 +17,15 @@ class Review < ApplicationRecord
     Review.order(rating: :desc).limit(3)
   end
 
+  def self.best_and_worst
+    if Review.all.count > 6
+      reviews_shown = Review.order(:rating).limit(3) + Review.order(rating: :desc).limit(3)
+    else
+      reviews_shown = Review.all
+    end
+    reviews_shown
+  end
+
   def self.avg_rating
     Review.average(:rating).round(2)
   end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -17,16 +17,13 @@
       <p><%= link_to "Edit Item", "/items/#{@item.id}/edit" %></p>
       <p><%= link_to "Delete Item", "/items/#{@item.id}", method: :delete %></p>
     <section id = "review-stats">
+      <h2>Helpful Reviews</h2>
       <% if !@item.reviews.empty? %>
-        <p> <% @item.reviews.top.each do |review| %></p>
+        <p> <% @item.reviews.best_and_worst.each do |review| %></p>
           <p><%= review.title %></p>
           <p><%= review.rating %></p>
         <% end %>
-        <p> <% @item.reviews.bottom.each do |review| %></p>
-          <p><%= review.title %></p>
-          <p><%= review.rating %></p>
-        <% end %>
-        <p> <%= @item.reviews.avg_rating %></p>
+        <p> Average User Rating:  <%= @item.reviews.avg_rating %></p>
       <% end %>
     </section>
       <p><%= button_to 'Add Review', "/items/#{@item.id}/reviews/new", method: :get %></p>

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe 'item show page', type: :feature do
   end
 
   it 'shows title and rating of top 3 reviews' do
-    save_and_open_page
     within "#review-stats" do
       expect(page).to have_content("first review")
       expect(page).to have_content("second review")


### PR DESCRIPTION
If there were less than six reviews, reviews used to show up in both bottom and top reviews. New commit accounts for this and only shows each review once in the top/bottom reviews section.