### PR TITLE
Add ability to empty all items from cart and change pluralize message

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -10,7 +10,12 @@ class CartController < ApplicationController
     cart.add_item(item.id)
     session[:cart] = cart.contents
     quantity = cart.count_of(item.id)
-    flash[:notice] = "You now #{pluralize(quantity, "copy")} of #{item.name} in your cart."
+    flash[:notice] = "You now have #{pluralize(quantity, item.name)} in your cart."
     redirect_to '/items'
+  end
+
+  def destroy
+    session[:cart] = Hash.new(0)
+    redirect_to '/cart'
   end
 end

--- a/app/views/cart/show.html.erb
+++ b/app/views/cart/show.html.erb
@@ -10,6 +10,7 @@
   <% end %>
   <hr>
   <p>Grand Total: <%= cart.grand_total %> </p>
+  <%= button_to 'Empty Cart', '/cart', method: :delete %>
 <% else %>
   <h3>Your cart is empty</h3>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,4 +28,5 @@ Rails.application.routes.draw do
 
   get '/cart', to: 'cart#show'
   patch '/cart/:item_id', to: 'cart#update'
+  delete '/cart', to: 'cart#destroy'
 end

--- a/spec/features/cart/add_item_spec.rb
+++ b/spec/features/cart/add_item_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "When a user adds items to their cart" do
 
     click_button 'Add to Cart'
 
-    expect(page).to have_content("You now 1 copy of #{@tire.name} in your cart.")
+    expect(page).to have_content("You now have 1 #{@tire.name} in your cart.")
   end
 
   it "the message correctly increments for multiple items" do
@@ -29,7 +29,7 @@ RSpec.describe "When a user adds items to their cart" do
 
     click_button 'Add to Cart'
 
-    expect(page).to have_content("You now 2 copies of #{@tire.name} in your cart")
+    expect(page).to have_content("You now have 2 #{@tire.name} in your cart")
   end
 
   it "displays total number of items in cart" do

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -41,10 +41,24 @@ RSpec.describe "As a visitor" do
     end
 
     it 'A message appears saying there are no items when the cart is empty' do
-
       visit '/cart'
 
       expect(page).to have_content('Your cart is empty')
+    end
+
+    it 'I can click a button to empty my cart' do
+      visit "/items/#{@tire.id}"
+
+      click_button 'Add to Cart'
+
+      visit '/cart'
+
+      click_button 'Empty Cart'
+
+      expect(current_path).to eq('/cart')
+
+      expect(page).to have_content('Your cart is empty')
+      expect(page).to have_content('Cart: 0')
     end
   end
 end


### PR DESCRIPTION
- User can empty cart from cart show page
- Confirmation message of item added to cart changed to pluralize item, instead of copy
- All tests passing

Co-authored-by: Ryan Hantak <47759923+rhantak@users.noreply.github.com>