### PR TITLE
Add functionality to item#destroy to allow for deletion of items with…

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -53,8 +53,8 @@ class ItemsController<ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
+    Review.delete(Review.where(item_id: params[:id]))
+    Item.destroy(params[:id])
     redirect_to "/items"
   end
 

--- a/spec/features/items/destroy_spec.rb
+++ b/spec/features/items/destroy_spec.rb
@@ -2,13 +2,26 @@ require 'rails_helper'
 
 RSpec.describe 'item delete', type: :feature do
   describe 'when I visit an item show page' do
-    it 'I can delete an item' do
+    it 'I can click a link to delete an item' do
       bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
       chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
 
       visit "/items/#{chain.id}"
 
       expect(page).to have_link("Delete Item")
+
+      click_on "Delete Item"
+
+      expect(current_path).to eq("/items")
+      expect(page).to_not have_css("#item-#{chain.id}")
+    end
+
+    it "Clicking the link will delete an item even if it has reviews" do
+      bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+      chain = bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      review = chain.reviews.create(title: "I love it", content: "Totally fixed my bike issues.", rating: 5)
+
+      visit "/items/#{chain.id}"
 
       click_on "Delete Item"
 


### PR DESCRIPTION
- Deleting an item now deletes all its reviews first, allowing for that item to be deleted regardless of having reviews attached to it