### PR TITLE
Render cart details on new_order page and form to enter shipping details

### DIFF
--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,1 +1,22 @@
 <h1>Checkout Page</h1>
+<% cart.cart_items.each do |item| %>
+  <section class = "grid-item" id= 'item-<%=item.id%>'>
+    <%= item.name %>
+    Sold by: <%= Merchant.find(item.merchant_id).name %>
+    Price: $<%= item.price %>
+    Quantity: <%= cart.count_of(item.id) %>
+    Subtotal: $<%= cart.subtotal(item.id) %>
+  </section>
+<% end %>
+<p>Grand Total: $<%= cart.grand_total %></p>
+
+<center>
+  <%= form_tag 'cart/new_order', method: :post do %>
+    <%= text_field_tag :name, 'Name' %>
+    <%= text_field_tag :address, 'Address' %>
+    <%= text_field_tag :city, 'City' %>
+    <%= text_field_tag :state, 'State' %>
+    <%= text_field_tag :zip, 'Zip' %>
+    <%= submit_tag 'Create Order' %>
+  <% end %>
+</center>  

--- a/spec/features/orders/new_spec.rb
+++ b/spec/features/orders/new_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'New Order Page', type: :feature do
+  describe 'As a visitor' do
+    describe 'when I check out from my cart and visit the new order page' do
+      before(:each) do
+        @meg = Merchant.create(name: "Meg's Bike Shop", address: '123 Bike Rd.', city: 'Denver', state: 'CO', zip: 80203)
+        @tire = @meg.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+        @chain = @meg.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+        visit "/items/#{@tire.id}"
+        click_button 'Add to Cart'
+
+        visit "/items/#{@tire.id}"
+        click_button 'Add to Cart'
+
+        visit "/items/#{@chain.id}"
+        click_button 'Add to Cart'
+
+        visit '/cart/new_order'
+      end
+
+      it 'I see the details of my cart' do
+        within "#item-#{@tire.id}" do
+          expect(page).to have_content(@tire.name)
+          expect(page).to have_content(@meg.name)
+          expect(page).to have_content(@tire.price)
+          expect(page).to have_content('Quantity: 2')
+          expect(page).to have_content('Subtotal: $200')
+        end
+
+        within "#item-#{@chain.id}" do
+          expect(page).to have_content(@chain.name)
+          expect(page).to have_content(@meg.name)
+          expect(page).to have_content(@chain.price)
+          expect(page).to have_content('Quantity: 1')
+          expect(page).to have_content('Subtotal: $50')
+        end
+
+        expect(page).to have_content('Grand Total: $250')
+      end
+
+      it 'I see a form to enter my shipping info and a Create Order button' do
+        expect(page).to have_field(:name)
+        expect(page).to have_field(:address)
+        expect(page).to have_field(:city)
+        expect(page).to have_field(:state)
+        expect(page).to have_field(:zip)
+        expect(page).to have_button('Create Order')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- New order checkout page renders cart details and form where shipping details may be added
- All tests passing

Co-authored-by: Ryan Hantak <47759923+rhantak@users.noreply.github.com>