### PR TITLE
Merchant stats

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,6 +1,7 @@
 class Merchant <ApplicationRecord
   has_many :items
   has_many :item_orders, through: :items
+  has_many :orders, through: :item_orders
 
   validates_presence_of :name,
                         :address,
@@ -11,5 +12,17 @@ class Merchant <ApplicationRecord
 
   def has_item_orders?
     !item_orders.empty?
+  end
+
+  def number_of_items
+    items.count
+  end
+
+  def avg_price
+    items.average(:price)
+  end
+
+  def all_cities
+    orders.pluck(:city).uniq
   end
 end

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -6,3 +6,11 @@
 <ul><%= link_to "Update Merchant", "/merchants/#{@merchant.id}/edit" %></ul>
 <ul><%= link_to "Delete Merchant", "/merchants/#{@merchant.id}", method: :delete %>
 </ul>
+
+<section id = "merchant-stats">
+  <p>Number of Items: <%= @merchant.number_of_items %></p>
+  <p>Average Price: $<%= @merchant.avg_price %></p>
+  <p>
+    Satisfied Customers In: <%= @merchant.all_cities.to_sentence %>
+  </p>
+</section>

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -4,18 +4,17 @@ RSpec.describe 'merchant show page', type: :feature do
   describe 'As a user' do
     before :each do
       @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 23137)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+      visit "/merchants/#{@bike_shop.id}"
     end
 
     it 'I can see a merchants name, address, city, state, zip' do
-      visit "/merchants/#{@bike_shop.id}"
-
       expect(page).to have_content("Brian's Bike Shop")
       expect(page).to have_content("123 Bike Rd.\nRichmond, VA 23137")
     end
 
     it 'I can see a link to visit the merchant items' do
-      visit "/merchants/#{@bike_shop.id}"
-
       expect(page).to have_link("All #{@bike_shop.name} Items")
 
       click_on "All #{@bike_shop.name} Items"
@@ -23,5 +22,45 @@ RSpec.describe 'merchant show page', type: :feature do
       expect(current_path).to eq("/merchants/#{@bike_shop.id}/items")
     end
 
+
+    describe 'I see a merchant stats section' do
+      it "has the total count of unique items sold by the merchant" do
+        within "#merchant-stats" do
+          expect(page).to have_content("Number of Items: 2")
+        end
+      end
+
+      it "has the average price of all items sold by the merchant" do
+        within "#merchant-stats" do
+          expect(page).to have_content("Average Price: $75")
+        end
+      end
+
+      it "Shows a list of cities from which items have been ordered" do
+        within "#merchant-stats" do
+          cart = Cart.new({})
+          cart.add_item(@tire.id)
+          cart.add_item(@tire.id)
+          @order_1 = Order.create(name: "Bob", address: "123 Street", city: "Denver", state: "CO", zip: "80232", grand_total: 250)
+          @order_1.generate_item_orders(cart)
+          cart = Cart.new({})
+          cart.add_item(@tire.id)
+          cart.add_item(@chain.id)
+          cart.add_item(@chain.id)
+          @order_2 = Order.create(name: "Joe", address: "234 Drive", city: "Boston", state: "MA", zip: "10101", grand_total: 200)
+          @order_2.generate_item_orders(cart)
+          cart = Cart.new({})
+          cart.add_item(@chain.id)
+          @order_3 = Order.create(name: "Sam", address: "345 Way", city: "Cambridge", state: "MA", zip: "10101", grand_total: 200)
+          @order_3.generate_item_orders(cart)
+
+          visit "/merchants/#{@bike_shop.id}"
+
+          save_and_open_page
+
+          expect(page).to have_content("Satisfied Customers In: Denver, Boston, and Cambridge")
+        end
+      end
+    end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -56,8 +56,6 @@ RSpec.describe 'merchant show page', type: :feature do
 
           visit "/merchants/#{@bike_shop.id}"
 
-          save_and_open_page
-
           expect(page).to have_content("Satisfied Customers In: Denver, Boston, and Cambridge")
         end
       end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -68,7 +68,7 @@ describe Merchant, type: :model do
       @order_3 = Order.create(name: "Sam", address: "345 Way", city: "Boston", state: "MA", zip: "10101", grand_total: 200)
       @order_3.generate_item_orders(cart)
 
-      expect(@bike_shop.all_cities).to eq(["Denver", "Boston"])
+      expect(@bike_shop.all_cities.sort).to eq(["Boston", "Denver"])
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -11,6 +11,8 @@ describe Merchant, type: :model do
 
   describe "relationships" do
     it {should have_many :items}
+    it {should have_many :item_orders}
+    it {should have_many :orders}
   end
 
   describe "instance methods" do
@@ -27,6 +29,46 @@ describe Merchant, type: :model do
 
 
       expect(bike_shop.has_item_orders?).to eq(true)
+    end
+  end
+
+  describe "instance methods" do
+    before(:each) do
+      @bike_shop = Merchant.create(name: "Brian's Bike Shop", address: '123 Bike Rd.', city: 'Richmond', state: 'VA', zip: 80203)
+      @chain = @bike_shop.items.create(name: "Chain", description: "It'll never break!", price: 50, image: "https://www.rei.com/media/b61d1379-ec0e-4760-9247-57ef971af0ad?size=784x588", inventory: 5)
+      @tire = @bike_shop.items.create(name: "Gatorskins", description: "They'll never pop!", price: 100, image: "https://www.rei.com/media/4e1f5b05-27ef-4267-bb9a-14e35935f218?size=784x588", inventory: 12)
+    end
+
+    it "can count how many different items it is selling" do
+      expect(@bike_shop.number_of_items).to eq(2)
+      @chain.delete
+      expect(@bike_shop.number_of_items).to eq(1)
+    end
+
+    it "can calculate the average price of all its items" do
+      expect(@bike_shop.avg_price).to eq(75)
+      @chain.delete
+      expect(@bike_shop.avg_price).to eq(100)
+    end
+
+    it "can identify all cities where its items have been ordered" do
+      cart = Cart.new({})
+      cart.add_item(@tire.id)
+      cart.add_item(@tire.id)
+      @order_1 = Order.create(name: "Bob", address: "123 Street", city: "Denver", state: "CO", zip: "80232", grand_total: 250)
+      @order_1.generate_item_orders(cart)
+      cart = Cart.new({})
+      cart.add_item(@tire.id)
+      cart.add_item(@chain.id)
+      cart.add_item(@chain.id)
+      @order_2 = Order.create(name: "Joe", address: "234 Drive", city: "Boston", state: "MA", zip: "10101", grand_total: 200)
+      @order_2.generate_item_orders(cart)
+      cart = Cart.new({})
+      cart.add_item(@chain.id)
+      @order_3 = Order.create(name: "Sam", address: "345 Way", city: "Boston", state: "MA", zip: "10101", grand_total: 200)
+      @order_3.generate_item_orders(cart)
+
+      expect(@bike_shop.all_cities).to eq(["Denver", "Boston"])
     end
   end
 end


### PR DESCRIPTION
- Add method for a merchant to calculate how many unique items it has in its inventory
- Add method for a merchant to calculate the average price of its unique items
- Add method for a merchant to check what cities it has sold items in
- Add section to merchant show page called merchant stats, which show the output of all these methods