### PR TITLE
Make Update Order page consistent with other pages on site

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -29,6 +29,7 @@ ul{
   padding: 0px;
   text-align: center;
 }
+
 img{
   width: 50%;
 }
@@ -49,6 +50,7 @@ img{
  	text-align: center;
   align-items: center;
  }
+
  .item-show-grid{
   width: 60%;
  	display: grid;
@@ -126,6 +128,26 @@ img{
 
  #cart-buttons div {
    display: flex;
+   align-items: center;
+ }
+
+ #cart-buttons-update {
+   display: flex;
+   flex-direction: column;
+   align-items: right;
+ }
+
+ #cart-buttons-update input {
+   background-color: navy;
+ }
+
+ #cart-buttons-update form {
+   background-color: #848586;
+ }
+
+ #cart-buttons-update div {
+   display: flex;
+   justify-content: center;
  }
 
  #search-bar {
@@ -141,7 +163,6 @@ img{
    background-color: #848586;
    margin-left: 10px;
    width: 20%;
-
  }
 
  input[type=text], select {

--- a/app/views/orders/edit.html.erb
+++ b/app/views/orders/edit.html.erb
@@ -10,19 +10,25 @@
     <%= submit_tag 'Update Shipping Information' %>
   <% end %>
 </center>
-
+<hr>
 <section class="grid-container">
   <% @order.item_orders.each do |item_order| %>
-    <section class = "grid-item" id= 'item-<%=item_order.current_item.id%>'>
-      <%= item_order.current_item.name %>
+    <section class = "grid-item" id = 'item-<%=item_order.current_item.id%>'>
+      <%= link_to item_order.current_item.name, "/items/#{item_order.item_id}" %>
       <p>Sold by: <%= item_order.current_item.merchant.name %></p>
-      <p>Price: $<%= item_order.current_item.price %></p>
+      <p>Price: <%= number_to_currency(item_order.current_item.price) %></p>
       <p>Quantity: <%= item_order.quantity %></p>
-      <p>Subtotal: $<%= item_order.subtotal %></p>
-      <%= button_to 'Remove Item', "/verified_order/#{@order.id}/#{item_order.id}", method: :delete %>
+      <p>Subtotal: <%= number_to_currency(item_order.subtotal) %></p>
+      <section id="cart-buttons-update">
+        <div>
+          <%= button_to 'Remove', "/verified_order/#{@order.id}/#{item_order.id}", method: :delete %>
+        </div>
+      </section>
     </section>
   <% end %>
 </section>
-<p>Grand Total: $<%= @order.grand_total %></p>
-
-<%= button_to 'Delete Order', "/verified_order/#{@order.id}", method: :delete %>
+<hr>
+<center>
+  <h2>Grand Total: <%= number_to_currency(@order.grand_total) %><h2>
+  <%= button_to 'Delete Order', "/verified_order/#{@order.id}", method: :delete %>
+</center>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -2,7 +2,7 @@
 <p><%= @order.name %></p>
 <p> <%= @order.address %> </p>
 <p>
-  <%= @order.city %>
+  <%= @order.city %>,
   <%= @order.state %>
   <%= @order.zip %>
 </p>

--- a/app/views/orders/verified_order.html.erb
+++ b/app/views/orders/verified_order.html.erb
@@ -2,7 +2,7 @@
 <p><%= @order.name %></p>
 <p> <%= @order.address %> </p>
 <p>
-  <%= @order.city %>
+  <%= @order.city %>,
   <%= @order.state %>
   <%= @order.zip %>
 </p>
@@ -10,15 +10,15 @@
 <section class="grid-container">
   <% @order.item_orders.each do |item_order| %>
     <section class="grid-item" id = "item-<%=item_order.item_id%>">
-      <p><%= item_order.current_item.name %></p>
+      <p><%= link_to item_order.current_item.name, "/items/#{item_order.item_id}" %></p>
       <p><%= item_order.current_item.merchant.name %></p>
-      <p>Price: $<%= item_order.current_item.price %></p>
+      <p>Price: <%= number_to_currency(item_order.current_item.price) %></p>
       <p>Quantity: <%= item_order.quantity %></p>
-      <p>Subtotal: $<%= item_order.subtotal %></p>
+      <p>Subtotal: <%= number_to_currency(item_order.subtotal) %></p>
     </section>
   <% end %>
 </section>
 <hr>
-<p>Grand Total: $<%= @order.grand_total %></p>
+<p>Grand Total: <%= number_to_currency(@order.grand_total) %></p>
 <p>Ordered on: <%= @order.created_at.strftime('%B %d, %Y') %></p>
 <p> <%= button_to 'Edit Order', "/verified_order/#{@order.id}/edit", method: :get %></p>

--- a/spec/features/orders/edit_spec.rb
+++ b/spec/features/orders/edit_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe "As a visitor" do
 
     it "I can use the buttons I see to remove an item from my order" do
       within "#item-#{@tire.id}" do
-        expect(page).to have_button("Remove Item")
-        click_button 'Remove Item'
+        expect(page).to have_button("Remove")
+        click_button 'Remove'
       end
 
       expect(page).to_not have_css("#item-#{@tire.id}")
@@ -60,13 +60,13 @@ RSpec.describe "As a visitor" do
 
     it "If I remove the last item from my order, my order is deleted" do
       within "#item-#{@tire.id}" do
-        expect(page).to have_button("Remove Item")
-        click_button 'Remove Item'
+        expect(page).to have_button("Remove")
+        click_button 'Remove'
       end
 
       within "#item-#{@chain.id}" do
-        expect(page).to have_button("Remove Item")
-        click_button 'Remove Item'
+        expect(page).to have_button("Remove")
+        click_button 'Remove'
       end
 
       expect(current_path).to eq("/merchants")


### PR DESCRIPTION
- Separate cart buttons ID created to account for different form layout on Update Order page
- Button name for item changed to 'Remove' on Update Order page
- Item links added to items on Update Order page
- Prices should now appear as currency throughout site
- Comma added between city and state for address
- All tests passing

Co-authored-by: Ryan Hantak <47759923+rhantak@users.noreply.github.com>